### PR TITLE
Added icons for .md files to MarkdownProvider

### DIFF
--- a/VSIX/MarkdownProvider/MarkdownProvider.csproj
+++ b/VSIX/MarkdownProvider/MarkdownProvider.csproj
@@ -27,6 +27,11 @@
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
@@ -110,6 +115,10 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="icons.pkgdef">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="MarkdownProvider.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -121,7 +130,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/VSIX/MarkdownProvider/icons.pkgdef
+++ b/VSIX/MarkdownProvider/icons.pkgdef
@@ -1,0 +1,3 @@
+
+[$RootKey$\ShellFileAssociations\.md]
+"DefaultIconMoniker"="KnownMonikers.MarkdownFile"

--- a/VSIX/MarkdownProvider/source.extension.vsixmanifest
+++ b/VSIX/MarkdownProvider/source.extension.vsixmanifest
@@ -1,21 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="MdProviderSetup.Lucian.9a837d80-5884-4394-b501-2bd3363593b6" Version="1.0" Language="en-US" Publisher="Lucian Wischik" />
-    <DisplayName>Markdown Provider for Solution Explorer</DisplayName>
-    <Description xml:space="preserve">Adds support for browsing the headings of a .md file in Solution Explorer</Description>
-    <MoreInfo>https://github.com/ljw1004/blog/blob/master/VSIX/MarkdownProvider/README.md</MoreInfo>
-    <Icon>MarkdownProvider.png</Icon>
-    <PreviewImage>screenshot.png</PreviewImage>
-    <Tags>markdown</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="14.0" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="MdProviderSetup.Lucian.9a837d80-5884-4394-b501-2bd3363593b6" Version="1.0" Language="en-US" Publisher="Lucian Wischik" />
+        <DisplayName>Markdown Provider for Solution Explorer</DisplayName>
+        <Description xml:space="preserve">Adds support for browsing the headings of a .md file in Solution Explorer</Description>
+        <MoreInfo>https://github.com/ljw1004/blog/blob/master/VSIX/MarkdownProvider/README.md</MoreInfo>
+        <Icon>MarkdownProvider.png</Icon>
+        <PreviewImage>screenshot.png</PreviewImage>
+        <Tags>markdown</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="14.0" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="icons.pkgdef" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
This PR adds the markdown icons to **.md** files in Solution Explorer.

![image](https://cloud.githubusercontent.com/assets/1258877/14289744/f9aeeec0-fb10-11e5-9aef-67c21965200d.png)
