### PR TITLE
Support for Additional MD File Extensions in MarkdownProvider

### DIFF
--- a/VSIX/MarkdownProvider/MarkdownProvider.cs
+++ b/VSIX/MarkdownProvider/MarkdownProvider.cs
@@ -85,7 +85,7 @@ namespace MarkdownSolutionExplorerProvider
             }
         }
 
-        private static readonly string[] KnownMdFileExtensions = { ".md", ".markdown" };
+        private static readonly string[] KnownMdFileExtensions = { ".md", ".markdown", ".spec", ".cpt" };
 
         private static bool IsMdFile(GraphNode node)
             => node.HasCategory(CodeNodeCategories.ProjectItem) &&

--- a/VSIX/MarkdownProvider/MarkdownProvider.cs
+++ b/VSIX/MarkdownProvider/MarkdownProvider.cs
@@ -5,10 +5,9 @@ using System.IO;
 using System.Linq;
 using System.Windows.Threading;
 using Microsoft.VisualStudio.GraphModel;
+using Microsoft.VisualStudio.GraphModel.CodeSchema;
 using Microsoft.VisualStudio.GraphModel.Schemas;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.GraphModel.CodeSchema;
-using System.Diagnostics;
 
 namespace MarkdownSolutionExplorerProvider
 {
@@ -86,10 +85,12 @@ namespace MarkdownSolutionExplorerProvider
             }
         }
 
+        private static readonly string[] KnownMdFileExtensions = { ".md" };
 
         private static bool IsMdFile(GraphNode node)
             => node.HasCategory(CodeNodeCategories.ProjectItem) &&
-               node.Id.GetNestedValueByName<Uri>(CodeGraphNodeIdName.File).LocalPath.EndsWith(".md");
+               KnownMdFileExtensions.Any(knownMdFileExtension =>
+                   node.Id.GetNestedValueByName<Uri>(CodeGraphNodeIdName.File).LocalPath.EndsWith(knownMdFileExtension));
 
         private IEnumerable<Tuple<string,SourceLocation>> GetMdHeadings(GraphNode file)
         {

--- a/VSIX/MarkdownProvider/MarkdownProvider.cs
+++ b/VSIX/MarkdownProvider/MarkdownProvider.cs
@@ -85,7 +85,7 @@ namespace MarkdownSolutionExplorerProvider
             }
         }
 
-        private static readonly string[] KnownMdFileExtensions = { ".md" };
+        private static readonly string[] KnownMdFileExtensions = { ".md", ".markdown" };
 
         private static bool IsMdFile(GraphNode node)
             => node.HasCategory(CodeNodeCategories.ProjectItem) &&

--- a/VSIX/MarkdownProvider/MarkdownProvider.cs
+++ b/VSIX/MarkdownProvider/MarkdownProvider.cs
@@ -88,9 +88,13 @@ namespace MarkdownSolutionExplorerProvider
         private static readonly string[] KnownMdFileExtensions = { ".md", ".markdown", ".spec", ".cpt" };
 
         private static bool IsMdFile(GraphNode node)
-            => node.HasCategory(CodeNodeCategories.ProjectItem) &&
+        {
+            var localPath = node.Id.GetNestedValueByName<Uri>(CodeGraphNodeIdName.File).LocalPath;
+
+            return node.HasCategory(CodeNodeCategories.ProjectItem) &&
                KnownMdFileExtensions.Any(knownMdFileExtension =>
-                   node.Id.GetNestedValueByName<Uri>(CodeGraphNodeIdName.File).LocalPath.EndsWith(knownMdFileExtension));
+                   localPath.EndsWith(knownMdFileExtension));
+        }
 
         private IEnumerable<Tuple<string,SourceLocation>> GetMdHeadings(GraphNode file)
         {


### PR DESCRIPTION
- Refactored `IsMdFile(string)` to check the extension of the solution file against an array of known MD file extensions.
- Added `.markdown` to the list of known MD file extensions.
- Added _Gauge_ files (http://getgauge.io) that implement the MD specification to the list of known MD file extensions.
  - Specification files (`.spec`); and
  - Concept Definition files (`.cpt`)
- `KnownMdFileExtensions.Any(...)` enumerates over all members of the `KnownMdFileExtensions` array and invokes a method, `.GetNestedValueByName(...)`, on each enumeration. This means, currently, this gets invoked 4 times (and more if we add additional known MD file types). I've therefore refactored this to ensure this is only called once, but this means I've had to refactor `IsMdFile(string)` from an _expression-bodied function_ to _statement_ block. Shame, but more efficient.
